### PR TITLE
Check that logit_bias value and not key is a float

### DIFF
--- a/aleph_alpha_client/aleph_alpha_client.py
+++ b/aleph_alpha_client/aleph_alpha_client.py
@@ -256,7 +256,7 @@ class AlephAlphaClient:
             for k, v in logit_bias.items():
                 if not isinstance(k, int):
                     raise ValueError("a key in the logit_bias dict must be an integer")
-                if not isinstance(k, float):
+                if not isinstance(v, float):
                     raise ValueError("a value in the logit_bias dict must be a float")
         if not (log_probs is None or isinstance(log_probs, int)):
             raise ValueError("log_probs must be an int or None")


### PR DESCRIPTION
We were checking the wrong variable for logit_bias validation.

I'm also confused why the many tests around this didn't catch it... Probably the tests were catching the wrong error would be my guess: https://github.com/Aleph-Alpha/aleph-alpha-client/blob/e6f2f1ef23216c91a9e1812f7b2559901b5c84ce/tests/testcases/test_errors.py#L169