### PR TITLE
Remove checkpoint tests from system-tests

### DIFF
--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -34,7 +34,6 @@ async def test_can_complete_with_async_client(
     assert response.model_version is not None
 
 
-@pytest.mark.system_test
 async def test_can_complete_with_async_client_against_checkpoint(
     async_client: AsyncClient, checkpoint_name: str
 ):
@@ -99,7 +98,6 @@ def test_complete_with_token_ids(sync_client: Client, model_name: str):
     assert response.model_version is not None
 
 
-@pytest.mark.system_test
 def test_complete_against_checkpoint(sync_client: Client, checkpoint_name: str):
 
     request = CompletionRequest(
@@ -138,7 +136,6 @@ async def test_can_complete_with_sync_client_against_checkpoint_and_adapter(
 # AlephAlphaClient
 
 
-@pytest.mark.system_test
 def test_complete_with_deprecated_client_against_checkpoint(
     client: AlephAlphaClient, checkpoint_name: str
 ):

--- a/tests/test_detokenize.py
+++ b/tests/test_detokenize.py
@@ -26,7 +26,6 @@ async def test_can_detokenization_with_async_client(
     assert len(response.result) > 0
 
 
-@pytest.mark.system_test
 async def test_can_detokenization_with_async_client_with_checkpoint(
     async_client: AsyncClient, checkpoint_name: str
 ):
@@ -46,7 +45,6 @@ def test_detokenize(sync_client: Client, model_name: str):
     assert response.result is not None
 
 
-@pytest.mark.system_test
 def test_detokenize_against_checkpoint(sync_client: Client, checkpoint_name: str):
     response = sync_client.detokenize(
         DetokenizationRequest([4711]), checkpoint=checkpoint_name
@@ -65,7 +63,6 @@ def test_detokenize_with_client(client: AlephAlphaClient, model_name: str):
     assert response["result"] is not None
 
 
-@pytest.mark.system_test
 def test_detokenize_with_client_against_checkpoint(
     client: AlephAlphaClient, checkpoint_name: str
 ):

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -35,7 +35,6 @@ async def test_can_embed_with_async_client(async_client: AsyncClient, model_name
     assert response.tokens is not None
 
 
-@pytest.mark.system_test
 async def test_can_embed_with_async_client_against_checkpoint(
     async_client: AsyncClient, checkpoint_name: str
 ):
@@ -67,7 +66,6 @@ async def test_can_semantic_embed_with_async_client(
     assert len(response.embedding) == 128
 
 
-@pytest.mark.system_test
 async def test_can_semantic_embed_with_async_client_against_checkpoint(
     async_client: AsyncClient, checkpoint_name: str
 ):
@@ -102,7 +100,6 @@ def test_embed(sync_client: Client, model_name: str):
     assert result.tokens is None
 
 
-@pytest.mark.system_test
 def test_embed_against_checkpoint(sync_client: Client, checkpoint_name: str):
 
     request = EmbeddingRequest(
@@ -170,7 +167,6 @@ def test_embed_semantic(sync_client: Client):
     assert len(result.embedding) == 128
 
 
-@pytest.mark.system_test
 def test_embed_semantic_against_checkpoint(sync_client: Client, checkpoint_name: str):
     request = SemanticEmbeddingRequest(
         prompt=Prompt.from_text("hello"),
@@ -202,7 +198,6 @@ def test_embed_with_client(client: AlephAlphaClient, model_name: str):
     assert result["tokens"] is None
 
 
-@pytest.mark.system_test
 def test_embed_with_client_against_checkpoint(
     client: AlephAlphaClient, checkpoint_name: str
 ):
@@ -242,7 +237,6 @@ def test_embed_semantic_with_client(client: AlephAlphaClient):
     assert len(result["embedding"]) == 128
 
 
-@pytest.mark.system_test
 def test_semantic_embed_with_client_against_checkpoint(
     client: AlephAlphaClient, checkpoint_name: str
 ):

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -32,7 +32,6 @@ async def test_can_evaluate_with_async_client(
     assert response.result is not None
 
 
-@pytest.mark.system_test
 async def test_can_evaluate_with_async_client_against_checkpoint(
     async_client: AsyncClient, checkpoint_name: str
 ):
@@ -61,7 +60,6 @@ def test_evaluate(sync_client: Client, model_name: str):
     assert result.result is not None
 
 
-@pytest.mark.system_test
 def test_evaluate_against_checkpoint(sync_client: Client, checkpoint_name: str):
     request = EvaluationRequest(
         prompt=Prompt.from_text("hello"), completion_expected="world"
@@ -84,7 +82,6 @@ def test_evaluate_with_client(client: AlephAlphaClient, model_name: str):
     assert result["result"] is not None
 
 
-@pytest.mark.system_test
 def test_evaluate_with_client_against_checkpoint(
     client: AlephAlphaClient, checkpoint_name: str
 ):

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -17,7 +17,6 @@ from tests.common import (
 # AsynClient
 
 
-@pytest.mark.system_test
 async def test_can_explain_with_async_client(
     async_client: AsyncClient, model_name: str
 ):
@@ -31,7 +30,6 @@ async def test_can_explain_with_async_client(
     assert response.result
 
 
-@pytest.mark.system_test
 async def test_can_explain_with_async_client_against_checkpoint(
     async_client: AsyncClient,
     checkpoint_name: str,
@@ -49,7 +47,6 @@ async def test_can_explain_with_async_client_against_checkpoint(
 # Client
 
 
-@pytest.mark.system_test
 def test_explanation(sync_client: Client, model_name: str):
     request = ExplanationRequest(
         prompt=Prompt.from_text("An apple a day"),
@@ -62,7 +59,6 @@ def test_explanation(sync_client: Client, model_name: str):
     assert len(explanation.result) > 0
 
 
-@pytest.mark.system_test
 def test_explanation_against_checkpoint(sync_client: Client, checkpoint_name: str):
     request = ExplanationRequest(
         prompt=Prompt.from_text("An apple a day"),
@@ -77,7 +73,6 @@ def test_explanation_against_checkpoint(sync_client: Client, checkpoint_name: st
 # AlephAlphaClient
 
 
-@pytest.mark.system_test
 def test_explanation_with_client_against_checkpoint(
     client: AlephAlphaClient, checkpoint_name: str
 ):

--- a/tests/test_qa.py
+++ b/tests/test_qa.py
@@ -28,7 +28,6 @@ async def test_can_qa_with_async_client(async_client: AsyncClient):
     assert response.answers[0].score > 0.0
 
 
-@pytest.mark.system_test
 async def test_can_qa_with_async_client_against_checkpoint(
     async_client: AsyncClient, qa_checkpoint_name: str
 ):
@@ -61,7 +60,6 @@ def test_qa(sync_client: Client):
     assert response.model_version is not None
 
 
-@pytest.mark.system_test
 def test_qa_against_checkpoint(sync_client: Client, qa_checkpoint_name: str):
     request = QaRequest(
         query="Who likes pizza?",
@@ -128,7 +126,6 @@ def test_qa_with_client(client: AlephAlphaClient):
     assert response["model_version"] is not None
 
 
-@pytest.mark.system_test
 def test_qa_with_client_against_checkpoint(
     client: AlephAlphaClient, qa_checkpoint_name: str
 ):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -3,7 +3,6 @@ from aleph_alpha_client import AsyncClient, Prompt, SearchRequest, Client
 from .common import async_client, sync_client
 
 
-@pytest.mark.system_test
 async def test_async_basic_functionality(
     async_client: AsyncClient,
 ):
@@ -17,7 +16,6 @@ async def test_async_basic_functionality(
     assert dict(response.results)["banana"] > dict(response.results)["jump"]
 
 
-@pytest.mark.system_test
 async def test_max_results(
     async_client: AsyncClient,
 ):
@@ -32,7 +30,6 @@ async def test_max_results(
     assert "banana" in dict(response.results)
 
 
-@pytest.mark.system_test
 async def test_min_score(
     async_client: AsyncClient,
 ):
@@ -47,7 +44,6 @@ async def test_min_score(
     assert "banana" in dict(response.results)
 
 
-@pytest.mark.system_test
 def test_sync_basic_functionality(
     sync_client: Client,
 ):

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -30,7 +30,6 @@ async def test_can_summarize_with_async_client(async_client: AsyncClient):
     assert response.model_version is not None
 
 
-@pytest.mark.system_test
 async def test_can_summarize_with_async_client_against_checkpoint(
     async_client: AsyncClient,
     summarization_checkpoint_name: str,
@@ -63,7 +62,6 @@ def test_summarize(sync_client: Client):
     assert response.model_version is not None
 
 
-@pytest.mark.system_test
 def test_summarize_against_checkpoint(
     sync_client: Client, summarization_checkpoint_name: str
 ):
@@ -110,9 +108,8 @@ def test_summarization_with_client(client: AlephAlphaClient):
     assert response["model_version"] is not None
 
 
-@pytest.mark.system_test
 def test_summarization_with_client_against_checkpoint(
-    client: AlephAlphaClient, summarization_checkpoint_name
+    client: AlephAlphaClient, summarization_checkpoint_name: str
 ):
     # when posting a Summarization request
     response = client.summarize(

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -27,7 +27,6 @@ async def test_can_tokenize_with_async_client(
     assert response.token_ids and len(response.token_ids) == 1
 
 
-@pytest.mark.system_test
 async def test_can_tokenize_with_async_client_with_checkpoint(
     async_client: AsyncClient, checkpoint_name: str
 ):
@@ -52,7 +51,6 @@ def test_tokenize(sync_client: Client, model_name: str):
     assert response.token_ids and len(response.token_ids) == 1
 
 
-@pytest.mark.system_test
 def test_tokenize_against_checkpoint(sync_client: Client, checkpoint_name: str):
     response = sync_client.tokenize(
         request=TokenizationRequest("Hello", tokens=True, token_ids=True),
@@ -74,7 +72,6 @@ def test_tokenize_with_client_against_model(client: AlephAlphaClient, model_name
     assert len(response["token_ids"]) == 1
 
 
-@pytest.mark.system_test
 def test_tokenize_with_client_against_checkpoint(
     client: AlephAlphaClient, checkpoint_name: str
 ):


### PR DESCRIPTION
Systems tests are run with Role "Client" which does not have access to checkpoints or "private" endpoints.