### PR TITLE
Respect http(s)_proxy env vars in AsyncClient (like in Client)

### DIFF
--- a/aleph_alpha_client/aleph_alpha_client.py
+++ b/aleph_alpha_client/aleph_alpha_client.py
@@ -1368,6 +1368,7 @@ class AsyncClient:
             statuses=set(RETRY_STATUS_CODES),
         )
         self.session = RetryClient(
+            trust_env=True,  # same behaviour as requests/(Sync)Client wrt. http_proxy
             raise_for_status=False,
             retry_options=retry_options,
             timeout=aiohttp.ClientTimeout(self.request_timeout_seconds),


### PR DESCRIPTION
`requests` uses the `http(s)_proxy` environment variables, `aiohttp` by default doesn't. This change allows the `AsyncClient` to work behind a proxy.