### PR TITLE
Enable 2 retries for the client instances used in tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -36,7 +36,7 @@ def sync_client() -> Client:
     return Client(
         token=get_env_var("TEST_TOKEN"),
         host=get_env_var("TEST_API_URL"),
-        total_retries=0,
+        total_retries=2,
     )
 
 
@@ -45,7 +45,7 @@ async def async_client() -> AsyncIterable[AsyncClient]:
     async with AsyncClient(
         token=get_env_var("TEST_TOKEN"),
         host=get_env_var("TEST_API_URL"),
-        total_retries=0,
+        total_retries=2,
     ) as client:
         yield client
 


### PR DESCRIPTION
This will make our pipeline tests more stable.