### PR TITLE
Handle if a user instantiates a prompt with just text

### DIFF
--- a/aleph_alpha_client/prompt.py
+++ b/aleph_alpha_client/prompt.py
@@ -436,7 +436,7 @@ class Prompt(NamedTuple):
             ])
     """
 
-    items: Sequence[PromptItem]
+    items: Union[str, Sequence[PromptItem]]
 
     @staticmethod
     def from_text(
@@ -459,7 +459,10 @@ class Prompt(NamedTuple):
         return Prompt([Tokens(tokens, controls or [])])
 
     def to_json(self) -> Sequence[Mapping[str, Any]]:
-        return [_to_json(item) for item in self.items]
+        if isinstance(self.items, str):
+            return [_to_json(self.items)]
+        else:
+            return [_to_json(item) for item in self.items]
 
 
 def _to_json(item: PromptItem) -> Mapping[str, Any]:

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -13,6 +13,14 @@ from aleph_alpha_client.prompt import Text, TextControl
 from tests.common import sync_client, model_name
 
 
+def test_serialize_prompt_init_with_str():
+    text = "text prompt"
+    prompt = Prompt(text)
+    serialized_prompt = prompt.to_json()
+
+    assert serialized_prompt == [{"type": "text", "data": text}]
+
+
 def test_serialize_token_ids():
     tokens = [1, 2, 3, 4]
     prompt = Prompt.from_tokens(tokens)


### PR DESCRIPTION
It isn't an uncommon occurrence to have users instantiate a Prompt with
just a string. Since this is also how our API works, I don't blame them.
But when they do, every character becomes a text item, which causes
weird behavior with our tokenization and prompt optmizations.

This handles the case where a user does this, and serializes it
correctly. While it would be nice to have stricter types, I think unless
every user used mypy, the type hints still wouldn't alleviate the
confusion.