### PR TITLE
feature: export BusyError

### DIFF
--- a/aleph_alpha_client/__init__.py
+++ b/aleph_alpha_client/__init__.py
@@ -12,6 +12,7 @@ from .prompt_template import PromptTemplate
 from .aleph_alpha_client import (
     POOLING_OPTIONS,
     AsyncClient,
+    BusyError,
     Client,
     QuotaError,
 )
@@ -55,6 +56,7 @@ __all__ = [
     "AsyncClient",
     "BatchSemanticEmbeddingRequest",
     "BatchSemanticEmbeddingResponse",
+    "BusyError",
     "Client",
     "CompletionRequest",
     "CompletionResponse",


### PR DESCRIPTION
We need the `BusyError` in the Intelligence Layer in order to introduce retry logic.  