### PR TITLE
fix: do not send user header if version is unavailable

### DIFF
--- a/aleph_alpha_client/aleph_alpha_client.py
+++ b/aleph_alpha_client/aleph_alpha_client.py
@@ -25,7 +25,6 @@ from requests.structures import CaseInsensitiveDict
 from urllib3.util.retry import Retry
 from tqdm.asyncio import tqdm
 
-import aleph_alpha_client
 from aleph_alpha_client.explanation import (
     ExplanationRequest,
     ExplanationResponse,
@@ -54,7 +53,7 @@ from aleph_alpha_client.embedding import (
     SemanticEmbeddingRequest,
     SemanticEmbeddingResponse,
 )
-from aleph_alpha_client.version import MIN_API_VERSION
+from aleph_alpha_client.version import MIN_API_VERSION, user_agent_headers
 
 POOLING_OPTIONS = ["mean", "max", "last_token", "abs_max"]
 RETRY_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504})
@@ -200,8 +199,7 @@ class Client:
         self.session.headers = CaseInsensitiveDict(
             {
                 "Authorization": "Bearer " + self.token,
-                "User-Agent": "Aleph-Alpha-Python-Client-"
-                + aleph_alpha_client.__version__,
+                **user_agent_headers(),
             }
         )
         self.session.mount("https://", adapter)
@@ -720,8 +718,7 @@ class AsyncClient:
             timeout=aiohttp.ClientTimeout(self.request_timeout_seconds),
             headers={
                 "Authorization": "Bearer " + self.token,
-                "User-Agent": "Aleph-Alpha-Python-Client-"
-                + aleph_alpha_client.__version__,
+                **user_agent_headers(),
             },
             connector=connector,
         )

--- a/aleph_alpha_client/version.py
+++ b/aleph_alpha_client/version.py
@@ -1,5 +1,5 @@
 import importlib.metadata
-
+from typing import Dict
 import re
 from pathlib import Path
 import logging
@@ -21,7 +21,9 @@ def pyproject_version() -> str:
 
     To not break imports in cases where both, the pyproject.toml file and the package
     metadata are not available, no error is raised and a default version of 0.0.0
-    will be returned.
+    will be returned. One such case is building the package with `pip install git+url`,
+    where pip is not able to read the [tool.poetry.version] field and also does not
+    keep the pyproject.toml file when the package is installed.
     """
     NO_VERSION = "0.0.0"
     pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
@@ -46,3 +48,18 @@ __version__ = importlib.metadata.version("aleph-alpha-client")
 
 if __version__ == "0.0.0":
     __version__ = pyproject_version()
+
+
+def user_agent_headers() -> Dict[str, str]:
+    """User agent that should be send for specific versions of the SDK.
+
+    For some installations, the package version is not available (== 0.0.0).
+    Setting the user agent header to "Aleph-Alpha-Python-Client-0.0.0" causes the
+    API to return a response with some fields omitted (due to a bug with older
+    clients which can not handle the new fields). These omitted fields in turn cause
+    new clients to fail on deserialization. To prevent these errors, we omit the
+    user agent header in cases where the version is not available (== 0.0.0).
+    """
+    if __version__ != "0.0.0":
+        return {"User-Agent": "Aleph-Alpha-Python-Client-" + __version__}
+    return {}

--- a/aleph_alpha_client/version.py
+++ b/aleph_alpha_client/version.py
@@ -60,6 +60,7 @@ def user_agent_headers() -> Dict[str, str]:
     new clients to fail on deserialization. To prevent these errors, we omit the
     user agent header in cases where the version is not available (== 0.0.0).
     """
-    if __version__ != "0.0.0":
+    if __version__ == "0.0.0":
+        return {}
+    else:
         return {"User-Agent": "Aleph-Alpha-Python-Client-" + __version__}
-    return {}


### PR DESCRIPTION
When building the package with pip (e.g. pip install git+url), pip can not infer the package versions. Using the default version of 0.0.0 in the user headers would cause the api-scheduler to omit some fields, so no user header is send for these edge cases