### PR TITLE
test: Update model name in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ def generic_client(request: pytest.FixtureRequest) -> GenericClient:
 
 @pytest.fixture(scope="session")
 def model_name() -> str:
-    return "luminous-base"
+    return "qwen-qwq-32b"
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ def generic_client(request: pytest.FixtureRequest) -> GenericClient:
 
 @pytest.fixture(scope="session")
 def model_name() -> str:
-    return "qwen-qwq-32b"
+    return "qwen-235b-a22b"
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ def generic_client(request: pytest.FixtureRequest) -> GenericClient:
 
 @pytest.fixture(scope="session")
 def model_name() -> str:
-    return "qwen-235b-a22b"
+    return "pharia-1-llm-7b-control"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Update the model name from luminous-base to qwen-qwq-32b in the model_name fixture.