### PR TITLE
feat: Add to_json method to TextMessage class

### DIFF
--- a/aleph_alpha_client/chat.py
+++ b/aleph_alpha_client/chat.py
@@ -128,7 +128,7 @@ class ChatRequest:
     """
 
     model: str
-    messages: List[Message]
+    messages: List[Union[Message, TextMessage]]
     maximum_tokens: Optional[int] = None
     temperature: Optional[float] = None
     top_k: Optional[int] = None

--- a/aleph_alpha_client/chat.py
+++ b/aleph_alpha_client/chat.py
@@ -68,6 +68,17 @@ class TextMessage:
         )
 
 
+    # In multi-turn conversations the returned TextMessage is part of the chat
+    # history and converted to the prompt. As such, it requires conversion to
+    # json again. Here, the message content is a string, but can reuse the 
+    # _message_content_to_json function nonetheless.
+    def to_json(self) -> Mapping[str, Any]:
+        result = {
+            "role": self.role.value,
+            "content": _message_content_to_json(self.content),
+        }
+        return result
+
 def _message_content_to_json(content: Union[str, List[Union[str, Image]]]) -> Union[str, List[Mapping[str, Any]]]:
     if isinstance(content, str):
         return content

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import List, Union
 
 import pytest
 from PIL import Image
@@ -12,6 +13,7 @@ from aleph_alpha_client.chat import (
     Message,
     Role,
     StreamOptions,
+    TextMessage,
     Usage,
     stream_chat_item_from_json,
 )
@@ -303,7 +305,7 @@ def test_request_serialization_no_default_values() -> None:
 # We previously encountered an error in a multi-turn chat conversation.
 # The returned TextMessage could not be made part of the chat history for the 
 # next request as the method for serialization was missing. 
-# This test should catch such conversion issues. 
+# This test should catch such conversion issues.
 def test_multi_turn_chat_serialization(sync_client: Client, dummy_model_name: str):
     """Test that TextMessage can be serialized when included in multi-turn chat history."""
     # First turn
@@ -314,7 +316,7 @@ def test_multi_turn_chat_serialization(sync_client: Client, dummy_model_name: st
     first_response = sync_client.chat(first_request, model=dummy_model_name)
     
     # Second turn - includes the TextMessage from first response in history
-    messages_with_history = [
+    messages_with_history: List[Union[Message, TextMessage]] = [
         Message(role=Role.User, content="Hello"),
         first_response.message,  # This TextMessage must be serializable
         Message(role=Role.User, content="Follow up question"),

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -302,12 +302,17 @@ def test_request_serialization_no_default_values() -> None:
         ]
     }
 
-# We previously encountered an error in a multi-turn chat conversation.
-# The returned TextMessage could not be made part of the chat history for the 
-# next request as the method for serialization was missing. 
-# This test should catch such conversion issues.
+
 def test_multi_turn_chat_serialization(sync_client: Client, dummy_model_name: str):
-    """Test that TextMessage can be serialized when included in multi-turn chat history."""
+    """
+    Test that TextMessage can be serialized when included in multi-turn chat history.
+
+    We previously encountered an error in a multi-turn chat conversation.
+    The returned TextMessage could not be made part of the chat history for the 
+    next request as the method for serialization was missing. 
+    This test should catch such conversion issues.
+    """
+
     # First turn
     first_request = ChatRequest(
         messages=[Message(role=Role.User, content="Hello")],

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -299,3 +299,33 @@ def test_request_serialization_no_default_values() -> None:
             }
         ]
     }
+
+# We previously encountered an error in a multi-turn chat conversation.
+# The returned TextMessage could not be made part of the chat history for the 
+# next request as the method for serialization was missing. 
+# This test should catch such conversion issues. 
+def test_multi_turn_chat_serialization(sync_client: Client, dummy_model_name: str):
+    """Test that TextMessage can be serialized when included in multi-turn chat history."""
+    # First turn
+    first_request = ChatRequest(
+        messages=[Message(role=Role.User, content="Hello")],
+        model=dummy_model_name,
+    )
+    first_response = sync_client.chat(first_request, model=dummy_model_name)
+    
+    # Second turn - includes the TextMessage from first response in history
+    messages_with_history = [
+        Message(role=Role.User, content="Hello"),
+        first_response.message,  # This TextMessage must be serializable
+        Message(role=Role.User, content="Follow up question"),
+    ]
+    
+    second_request = ChatRequest(
+        messages=messages_with_history,
+        model=dummy_model_name,
+    )
+    
+    # This would fail if TextMessage.to_json() doesn't exist
+    serialized = second_request.to_json()
+    assert len(serialized["messages"]) == 3
+    assert serialized["messages"][1]["role"] == "assistant"


### PR DESCRIPTION
Add a to_json method to the TextMessage class to convert its content to JSON format. As such, the return type TextMessage can be used as part of a multi-turn conversion and be used as part of the chat history.