### PR TITLE
test: Adjust response_format for structured output

### DIFF
--- a/aleph_alpha_client/chat.py
+++ b/aleph_alpha_client/chat.py
@@ -4,6 +4,8 @@ from enum import Enum
 from io import BytesIO
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
+from pydantic import BaseModel
+
 from aleph_alpha_client.steering import SteeringConceptCreationResponse
 from aleph_alpha_client.structured_output import ResponseFormat
 from PIL.Image import Image
@@ -142,7 +144,7 @@ class ChatRequest:
         payload["messages"] = [message.to_json() for message in self.messages]
         if self.response_format:
             # Handle Pydantic models by converting them to JSONSchema first
-            if hasattr(self.response_format, 'model_json_schema'):
+            if isinstance(self.response_format, type) and issubclass(self.response_format, BaseModel):
                 # This is a Pydantic model, convert it to JSONSchema
                 from aleph_alpha_client.structured_output import JSONSchema
                 json_schema = JSONSchema.from_pydantic(self.response_format)

--- a/aleph_alpha_client/chat.py
+++ b/aleph_alpha_client/chat.py
@@ -141,7 +141,15 @@ class ChatRequest:
         payload = {k: v for k, v in asdict(self).items() if v is not None}
         payload["messages"] = [message.to_json() for message in self.messages]
         if self.response_format:
-            payload["response_format"] = self.response_format.to_json()
+            # Handle Pydantic models by converting them to JSONSchema first
+            if hasattr(self.response_format, 'model_json_schema'):
+                # This is a Pydantic model, convert it to JSONSchema
+                from aleph_alpha_client.structured_output import JSONSchema
+                json_schema = JSONSchema.from_pydantic(self.response_format)
+                payload["response_format"] = json_schema.to_json()
+            else:
+                # This is already a JSONSchema or compatible object
+                payload["response_format"] = self.response_format.to_json()
         return payload
 
 

--- a/aleph_alpha_client/structured_output.py
+++ b/aleph_alpha_client/structured_output.py
@@ -1,5 +1,6 @@
 from dataclasses import asdict, dataclass
 from typing import Any, Mapping, Optional, Union
+from pydantic import BaseModel
 
 
 @dataclass(frozen=True)
@@ -44,5 +45,37 @@ class JSONSchema:
     def to_json(self) -> Mapping[str, Any]:
         return {"type": "json_schema", "json_schema": asdict(self)}
 
+    @classmethod
+    def from_pydantic(cls, model_class) -> "JSONSchema":
+        """
+        Create a JSONSchema from a Pydantic model class.
+        
+        Parameters:
+            model_class: A Pydantic BaseModel class
+            
+        Returns:
+            JSONSchema instance with the schema generated from the Pydantic model
+            
+        Raises:
+            ValueError: If the provided class is not a Pydantic BaseModel
+        """
+        # Validate that the model_class is a Pydantic BaseModel
+        if not (isinstance(model_class, type) and issubclass(model_class, BaseModel)):
+            raise ValueError(f"Expected a Pydantic BaseModel class, got {type(model_class).__name__}")
+        
+        schema = model_class.model_json_schema()
+        name = getattr(model_class, '__name__', 'generated_schema')
 
-ResponseFormat = Union[JSONSchema]
+        # Use the name as default if no description is provided
+        description = getattr(model_class, '__doc__', name)
+
+        return cls(
+            schema=schema,
+            name=name,
+            description=description,
+            strict=True
+        )
+
+
+# Define ResponseFormat type - use Any to support both JSONSchema and Pydantic models
+ResponseFormat = Union[JSONSchema, Any]

--- a/aleph_alpha_client/structured_output.py
+++ b/aleph_alpha_client/structured_output.py
@@ -8,14 +8,30 @@ class JSONSchema:
     JSON schema that structured output must adhere to.
 
     Parameters:
-        json_schema:
+        schema:
             JSON schema that structured output must adhere to.
+        name:
+            Name of the schema.
+        description:
+            Description of the schema.
+        strict:
+            Whether the schema should be strictly enforced.
 
     Examples:
         >>> schema = JSONSchema(
-        >>>     schema={'type': 'object', 'properties': {'bar': {'type': 'integer'}}},
-        >>>     name="example_schema",
-        >>>     description="Example schema with a bar integer property",
+        >>>     schema={
+        >>>         'type': 'object',
+        >>>         'title': 'Aquarium',
+        >>>         'properties': {
+        >>>             'nemo': {
+        >>>                 'type': 'string',
+        >>>                 'title': 'Nemo'
+        >>>             }
+        >>>         },
+        >>>         'required': ['nemo']
+        >>>     },
+        >>>     name="aquarium",
+        >>>     description="Describe nemo",
         >>>     strict=True
         >>> )
     """

--- a/aleph_alpha_client/structured_output.py
+++ b/aleph_alpha_client/structured_output.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict, dataclass
-from typing import Any, Mapping, Optional, Union
+from typing import Any, Mapping, Optional, Union, Type
 from pydantic import BaseModel
 
 
@@ -46,7 +46,7 @@ class JSONSchema:
         return {"type": "json_schema", "json_schema": asdict(self)}
 
     @classmethod
-    def from_pydantic(cls, model_class) -> "JSONSchema":
+    def from_pydantic(cls, model_class: Type[BaseModel]) -> "JSONSchema":
         """
         Create a JSONSchema from a Pydantic model class.
         
@@ -59,9 +59,6 @@ class JSONSchema:
         Raises:
             ValueError: If the provided class is not a Pydantic BaseModel
         """
-        # Validate that the model_class is a Pydantic BaseModel
-        if not (isinstance(model_class, type) and issubclass(model_class, BaseModel)):
-            raise ValueError(f"Expected a Pydantic BaseModel class, got {type(model_class).__name__}")
         
         schema = model_class.model_json_schema()
         name = getattr(model_class, '__name__', 'generated_schema')
@@ -76,6 +73,4 @@ class JSONSchema:
             strict=True
         )
 
-
-# Define ResponseFormat type - use Any to support both JSONSchema and Pydantic models
-ResponseFormat = Union[JSONSchema, Any]
+ResponseFormat = Union[JSONSchema, Type[BaseModel]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "tqdm>=4.62.0",
     "python-liquid>=1.9.4,!=2.0.2",
     "packaging>=23.2",
+    "pydantic"
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,11 @@ def chat_model_name() -> str:
 
 
 @pytest.fixture(scope="session")
+def structured_output_model_name() -> str:
+    return "qwen3-32b-tool"
+
+
+@pytest.fixture(scope="session")
 def dummy_model_name() -> str:
     return "dummy-model"
 


### PR DESCRIPTION
Add required fields to the JSONSchema classs and adjust tests such that it adheres to the openai-compatible API