### PR TITLE
feat: expose connection limit on AsyncClient

### DIFF
--- a/aleph_alpha_client/aleph_alpha_client.py
+++ b/aleph_alpha_client/aleph_alpha_client.py
@@ -833,6 +833,7 @@ class AsyncClient:
         self,
         token: str,
         host: str,
+        limit: int = 100,
         hosting: Optional[str] = None,
         request_timeout_seconds: int = DEFAULT_REQUEST_TIMEOUT,
         total_retries: int = 8,
@@ -855,7 +856,7 @@ class AsyncClient:
             start_timeout=0.25,
             statuses=set(RETRY_STATUS_CODES),
         )
-        connector = aiohttp.TCPConnector(verify_ssl=verify_ssl)
+        connector = aiohttp.TCPConnector(verify_ssl=verify_ssl, limit=limit)
         self.session = RetryClient(
             trust_env=True,  # same behaviour as requests/(Sync)Client wrt. http_proxy
             raise_for_status=False,


### PR DESCRIPTION
before exposure of that parameter connection limits defaulted to 100
